### PR TITLE
chore: Swagger UIをdocker-composeに追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ docker compose exec api bundle exec rubocop
 docker compose exec api bundle exec rubocop -a
 ```
 
+## Swagger UI
+
+```bash
+# 起動（http://localhost:8080）
+docker compose up -d swagger
+```
+
 ## フロントエンド（Next.js）
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,15 @@ services:
       DATABASE_URL: postgresql://postgres:password@db:5432/couple_gifted_development
       BUNDLE_WITHOUT: ""
 
+  swagger:
+    image: swaggerapi/swagger-ui
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./api/openapi.yaml:/openapi.yaml
+    environment:
+      SWAGGER_JSON: /openapi.yaml
+
 volumes:
   postgres_data:
   bundle_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       BUNDLE_WITHOUT: ""
 
   swagger:
-    image: swaggerapi/swagger-ui
+    image: swaggerapi/swagger-ui:v5.32.6
     ports:
       - "8080:8080"
     volumes:

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,6 +35,17 @@
 4.「Specを通すControllerを実装して」
 5.「ロジックをServiceクラスに切り出して」
 
+## Swagger UI
+
+`api/openapi.yaml` をブラウザで確認できる。
+
+```bash
+# 起動（http://localhost:8080）
+docker compose up -d swagger
+```
+
+`openapi.yaml` を更新した場合はブラウザをリロードするだけで反映される。
+
 ## よく使うコマンド
 
 - docker compose exec api bundle exec rspec                          # 全テスト


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/couple-gifted/issues/57#issue-4470832642

# 概要

  `docker compose up -d swagger` で Swagger
  UI（http://localhost:8080）を起動できるようにした。`api/openapi.yaml`
  をマウントしており、ファイル更新後はブラウザリロードで即反映される。

  ## 変更内容

  - `docker-compose.yml` : `swaggerapi/swagger-ui`
  サービスを追加（ポート8080）
  - `README.md` : Swagger UI の起動コマンドを追記
  - `docs/development.md` : Swagger UI セクションを追加
  
## Swagger
<img width="1438" height="720" alt="スクリーンショット 2026-05-24 4 55 06" src="https://github.com/user-attachments/assets/707cf7a6-7c81-449f-82e9-1b1c5f7151f2" />

<img width="1428" height="757" alt="スクリーンショット 2026-05-24 4 55 25" src="https://github.com/user-attachments/assets/c4c9b237-8a05-42f6-ac12-120efbd9f834" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Swagger UI がコンテナサービスとして起動可能になりました。OpenAPI 定義をブラウザで確認できます。

* **Documentation**
  * Swagger UI の起動手順をREADMEと開発ドキュメントに追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hashimoto-Noriaki/couple-gifted/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->