### PR TITLE
chore: Claude Code設定の整備とトランクベース開発への移行

### DIFF
--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -2,7 +2,7 @@
 description: PRの説明文をテンプレートに沿って生成する
 ---
 
-1. ベースブランチを特定する（`develop` があれば優先、なければ `main` / `master`）
+1. ベースブランチは `master` を使う
 2. `git diff $(git merge-base HEAD <ベースブランチ>)..HEAD` で差分を確認する
 3. `.github/pull_request_template.md` のフォーマットに沿って PR 説明文を生成し、ユーザーに提示する
 4. ユーザーの承認を得たら、以下を順に実行してPRを作成する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,9 @@ CoupleGifted（カップルギフテッド）
 
 ## Gitルール
 
-- ブランチ: feature/ fix/ hotfix/ refactor/ docs/ chore/
+- トランクベース開発。`master` が唯一のメインブランチ
+- ブランチ: feature/ fix/ hotfix/ refactor/ docs/ chore/（短命・1〜2日でマージ）
 - コミット: feat: / fix: / hotfix: / test: / refactor: / docs: / chore:
+- PRは `master` をベースに作成する
 - PRを出したらCodeRabbitのレビューを確認してからマージ
 - PRマージ前に `/code-review` でコードレビュー、セキュリティが気になる変更は `/security-review` も実行する


### PR DESCRIPTION
# 概要

Claude Code の開発支援設定を整備し、ブランチ戦略をトランクベース開発に移行した。

## 変更内容

- `.claude/hooks/post-edit-biome.sh` — フロントエンドファイル編集後にBiomeを自動実行するフックを追加
- `.claude/settings.json` — denyリスト強化（docker volume削除・force push等）、Biomeフック登録、git add を allow から除外
- `.claude/skills/pr-description/SKILL.md` — ベースブランチを `master` 固定に変更、heredoc の記法を修正
- `CLAUDE.md` — トランクベース開発のGitルールを追記、コードレビュー方針を追加
- `docs/how-to-create-skill.md` — Claude Codeスキル作成ガイドを追加

## テスト計画

### フロントエンド

- [ ] `pnpm test run` が全件グリーン

## チェックリスト

- [ ] `pnpm exec biome check .` を実行した（フロントエンド変更時）