### PR TITLE
feat: 口コミ投稿・削除エンドポイントを追加

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -192,6 +192,63 @@ paths:
                       $ref: "#/components/schemas/SpotReviewData"
         "404":
           $ref: "#/components/responses/NotFound"
+    post:
+      tags: [spot_reviews]
+      summary: 口コミ投稿
+      security:
+        - tokenAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: スポットID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SpotReviewInput"
+      responses:
+        "201":
+          description: 口コミ投稿成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/SpotReviewData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+
+  /api/v1/spot_reviews/{id}:
+    delete:
+      tags: [spot_reviews]
+      summary: 口コミ削除（本人のみ）
+      security:
+        - tokenAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: 口コミID
+      responses:
+        "204":
+          description: 削除成功（ボディなし）
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
 components:
   securitySchemes:
@@ -253,6 +310,20 @@ components:
             google_place_id:
               type: string
 
+    SpotReviewInput:
+      type: object
+      required: [rating, body, relationship_status_at_visit]
+      properties:
+        rating:
+          type: integer
+          minimum: 1
+          maximum: 5
+        body:
+          type: string
+        relationship_status_at_visit:
+          type: string
+          enum: [dating, married]
+
     SpotReviewData:
       type: object
       required: [id, type, attributes]
@@ -296,6 +367,12 @@ components:
             $ref: "#/components/schemas/Error"
     UnprocessableEntity:
       description: バリデーションエラー
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Forbidden:
+      description: 権限なし
       content:
         application/json:
           schema:

--- a/backend/app/controllers/api/v1/spot_reviews_controller.rb
+++ b/backend/app/controllers/api/v1/spot_reviews_controller.rb
@@ -2,47 +2,44 @@ module Api
   module V1
     class SpotReviewsController < ApplicationController
       before_action :authenticate_user!, only: %i[create destroy]
-      before_action :set_spot, only: %i[index create]
-      before_action :set_review, only: %i[destroy]
-      before_action :authorize_owner!, only: %i[destroy]
 
       def index
-        reviews = @spot.spot_reviews.includes(:user)
+        spot = Spot.find(params[:spot_id])
+        reviews = spot.spot_reviews.includes(:user)
         render json: SpotReviewSerializer.new(reviews).serializable_hash
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "スポットが見つかりません" }, status: :not_found
       end
 
       def create
-        review = @spot.spot_reviews.build(spot_review_params.merge(user: current_user))
+        spot = Spot.find(params[:spot_id])
+        review = spot.spot_reviews.build(spot_review_params.merge(user: current_user))
 
         if review.save
           render json: SpotReviewSerializer.new(review).serializable_hash, status: :created
         else
           render json: { error: review.errors.full_messages.join(", ") }, status: :unprocessable_entity
         end
-      end
-
-      def destroy
-        @review.destroy!
-        head :no_content
-      end
-
-      private
-
-      def set_spot
-        @spot = Spot.find(params[:spot_id])
       rescue ActiveRecord::RecordNotFound
         render json: { error: "スポットが見つかりません" }, status: :not_found
       end
 
-      def set_review
-        @review = SpotReview.find(params[:id])
+      def destroy
+        review = SpotReview.find(params[:id])
+
+        unless review.owned_by?(current_user)
+          
+          render json: { error: "権限がありません" }, status: :forbidden
+          return
+        end
+
+        review.destroy!
+        head :no_content
       rescue ActiveRecord::RecordNotFound
         render json: { error: "口コミが見つかりません" }, status: :not_found
       end
 
-      def authorize_owner!
-        render json: { error: "権限がありません" }, status: :forbidden unless @review.owned_by?(current_user)
-      end
+      private
 
       def spot_review_params
         params.permit(:rating, :body, :relationship_status_at_visit)

--- a/backend/app/controllers/api/v1/spot_reviews_controller.rb
+++ b/backend/app/controllers/api/v1/spot_reviews_controller.rb
@@ -28,7 +28,7 @@ module Api
         review = SpotReview.find(params[:id])
 
         unless review.owned_by?(current_user)
-          
+
           render json: { error: "権限がありません" }, status: :forbidden
           return
         end

--- a/backend/app/controllers/api/v1/spot_reviews_controller.rb
+++ b/backend/app/controllers/api/v1/spot_reviews_controller.rb
@@ -2,43 +2,47 @@ module Api
   module V1
     class SpotReviewsController < ApplicationController
       before_action :authenticate_user!, only: %i[create destroy]
+      before_action :set_spot, only: %i[index create]
+      before_action :set_review, only: %i[destroy]
+      before_action :authorize_owner!, only: %i[destroy]
 
       def index
-        spot = Spot.find(params[:spot_id])
-        reviews = spot.spot_reviews.includes(:user)
+        reviews = @spot.spot_reviews.includes(:user)
         render json: SpotReviewSerializer.new(reviews).serializable_hash
-      rescue ActiveRecord::RecordNotFound
-        render json: { error: "スポットが見つかりません" }, status: :not_found
       end
 
       def create
-        spot = Spot.find(params[:spot_id])
-        review = spot.spot_reviews.build(spot_review_params.merge(user: current_user))
+        review = @spot.spot_reviews.build(spot_review_params.merge(user: current_user))
 
         if review.save
           render json: SpotReviewSerializer.new(review).serializable_hash, status: :created
         else
           render json: { error: review.errors.full_messages.join(", ") }, status: :unprocessable_entity
         end
+      end
+
+      def destroy
+        @review.destroy!
+        head :no_content
+      end
+
+      private
+
+      def set_spot
+        @spot = Spot.find(params[:spot_id])
       rescue ActiveRecord::RecordNotFound
         render json: { error: "スポットが見つかりません" }, status: :not_found
       end
 
-      def destroy
-        review = SpotReview.find(params[:id])
-
-        if review.user != current_user
-          render json: { error: "権限がありません" }, status: :forbidden
-          return
-        end
-
-        review.destroy!
-        head :no_content
+      def set_review
+        @review = SpotReview.find(params[:id])
       rescue ActiveRecord::RecordNotFound
         render json: { error: "口コミが見つかりません" }, status: :not_found
       end
 
-      private
+      def authorize_owner!
+        render json: { error: "権限がありません" }, status: :forbidden unless @review.owned_by?(current_user)
+      end
 
       def spot_review_params
         params.permit(:rating, :body, :relationship_status_at_visit)

--- a/backend/app/controllers/api/v1/spot_reviews_controller.rb
+++ b/backend/app/controllers/api/v1/spot_reviews_controller.rb
@@ -1,12 +1,47 @@
 module Api
   module V1
     class SpotReviewsController < ApplicationController
+      before_action :authenticate_user!, only: %i[create destroy]
+
       def index
         spot = Spot.find(params[:spot_id])
         reviews = spot.spot_reviews.includes(:user)
         render json: SpotReviewSerializer.new(reviews).serializable_hash
       rescue ActiveRecord::RecordNotFound
         render json: { error: "スポットが見つかりません" }, status: :not_found
+      end
+
+      def create
+        spot = Spot.find(params[:spot_id])
+        review = spot.spot_reviews.build(spot_review_params.merge(user: current_user))
+
+        if review.save
+          render json: SpotReviewSerializer.new(review).serializable_hash, status: :created
+        else
+          render json: { error: review.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        end
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "スポットが見つかりません" }, status: :not_found
+      end
+
+      def destroy
+        review = SpotReview.find(params[:id])
+
+        if review.user != current_user
+          render json: { error: "権限がありません" }, status: :forbidden
+          return
+        end
+
+        review.destroy!
+        head :no_content
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "口コミが見つかりません" }, status: :not_found
+      end
+
+      private
+
+      def spot_review_params
+        params.permit(:rating, :body, :relationship_status_at_visit)
       end
     end
   end

--- a/backend/app/models/spot_review.rb
+++ b/backend/app/models/spot_review.rb
@@ -5,4 +5,8 @@ class SpotReview < ApplicationRecord
   validates :rating, presence: true, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 5, only_integer: true }
   validates :body, presence: true
   validates :relationship_status_at_visit, presence: true
+
+  def owned_by?(user)
+    user_id == user.id
+  end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,8 +5,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :spots, only: %i[index show] do
-        resources :spot_reviews, only: %i[index]
+        resources :spot_reviews, only: %i[index create]
       end
+      resources :spot_reviews, only: %i[destroy]
       resources :tags, only: %i[index]
     end
   end

--- a/backend/spec/models/spot_review_spec.rb
+++ b/backend/spec/models/spot_review_spec.rb
@@ -15,4 +15,18 @@ RSpec.describe SpotReview, type: :model do
     it { should belong_to(:user) }
     it { should belong_to(:spot) }
   end
+
+  describe '#owned_by?' do
+    let(:owner) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:review) { create(:spot_review, user: owner) }
+
+    it 'オーナーに対してtrueを返す' do
+      expect(review.owned_by?(owner)).to be true
+    end
+
+    it '他のユーザーに対してfalseを返す' do
+      expect(review.owned_by?(other_user)).to be false
+    end
+  end
 end

--- a/backend/spec/models/spot_review_spec.rb
+++ b/backend/spec/models/spot_review_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe SpotReview, type: :model do
     it { should validate_presence_of(:rating) }
     it { should validate_presence_of(:body) }
     it { should validate_presence_of(:relationship_status_at_visit) }
+
+    it { should validate_numericality_of(:rating).only_integer.is_greater_than_or_equal_to(1).is_less_than_or_equal_to(5) }
   end
 
   describe 'アソシエーション' do

--- a/backend/spec/requests/spot_reviews_spec.rb
+++ b/backend/spec/requests/spot_reviews_spec.rb
@@ -54,4 +54,133 @@ RSpec.describe 'SpotReviews', type: :request do
       end
     end
   end
+
+  describe 'POST /api/v1/spots/:id/spot_reviews（口コミ投稿）' do
+    let!(:spot) { create(:spot) }
+    let!(:user) { create(:user) }
+    let(:auth_headers) { user.create_new_auth_token }
+    let(:valid_params) do
+      {
+        rating: 5,
+        body: '最高のデートスポットでした。',
+        relationship_status_at_visit: 'dating'
+      }
+    end
+
+    context '認証済みユーザーが正常なパラメータで投稿した場合' do
+      before { post "/api/v1/spots/#{spot.id}/spot_reviews", params: valid_params, headers: auth_headers }
+
+      it '201を返す' do
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'dataを含む' do
+        expect(JSON.parse(response.body)).to have_key('data')
+      end
+
+      it '投稿した口コミの内容を返す' do
+        json = JSON.parse(response.body)
+        attrs = json['data']['attributes']
+        expect(attrs['rating']).to eq(5)
+        expect(attrs['body']).to eq('最高のデートスポットでした。')
+        expect(attrs['relationship_status_at_visit']).to eq('dating')
+        expect(attrs['user_nickname']).to eq(user.nickname)
+      end
+
+      it 'DBに口コミが1件作成される' do
+        expect(SpotReview.count).to eq(1)
+      end
+    end
+
+    context '未認証の場合' do
+      before { post "/api/v1/spots/#{spot.id}/spot_reviews", params: valid_params }
+
+      it '401を返す' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '存在しないスポットの場合' do
+      before { post '/api/v1/spots/0/spot_reviews', params: valid_params, headers: auth_headers }
+
+      it '404を返す' do
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'エラーメッセージを返す' do
+        expect(JSON.parse(response.body)).to have_key('error')
+      end
+    end
+
+    context 'バリデーションエラーの場合' do
+      let(:invalid_params) { { rating: 6, body: '', relationship_status_at_visit: 'dating' } }
+
+      before { post "/api/v1/spots/#{spot.id}/spot_reviews", params: invalid_params, headers: auth_headers }
+
+      it '422を返す' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'エラーメッセージを返す' do
+        expect(JSON.parse(response.body)).to have_key('error')
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/spot_reviews/:id（口コミ削除）' do
+    let!(:owner) { create(:user) }
+    let!(:other_user) { create(:user) }
+    let!(:spot) { create(:spot) }
+    let!(:review) { create(:spot_review, user: owner, spot: spot) }
+    let(:owner_headers) { owner.create_new_auth_token }
+    let(:other_headers) { other_user.create_new_auth_token }
+
+    context '投稿者本人が削除する場合' do
+      before { delete "/api/v1/spot_reviews/#{review.id}", headers: owner_headers }
+
+      it '204を返す' do
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'DBから口コミが削除される' do
+        expect(SpotReview.find_by(id: review.id)).to be_nil
+      end
+    end
+
+    context '他のユーザーが削除しようとした場合' do
+      before { delete "/api/v1/spot_reviews/#{review.id}", headers: other_headers }
+
+      it '403を返す' do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'エラーメッセージを返す' do
+        expect(JSON.parse(response.body)).to have_key('error')
+      end
+
+      it 'DBから口コミが削除されない' do
+        expect(SpotReview.find_by(id: review.id)).not_to be_nil
+      end
+    end
+
+    context '未認証の場合' do
+      before { delete "/api/v1/spot_reviews/#{review.id}" }
+
+      it '401を返す' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '存在しない口コミの場合' do
+      before { delete '/api/v1/spot_reviews/0', headers: owner_headers }
+
+      it '404を返す' do
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'エラーメッセージを返す' do
+        expect(JSON.parse(response.body)).to have_key('error')
+      end
+    end
+  end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,13 +45,61 @@ GET    /api/v1/tags
 
 - 404: スポットが存在しない
 
-### POST /api/v1/spots/:id/spot_reviews（未実装）
+### POST /api/v1/spots/:id/spot_reviews
 
-要認証
+指定スポットに口コミを投稿する。認証必須。
 
-### DELETE /api/v1/spot_reviews/:id（未実装）
+**リクエストボディ:**
 
-要認証・本人のみ
+```json
+{
+  "rating": 4,
+  "body": "とても良いスポットでした。",
+  "relationship_status_at_visit": "dating"
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| rating | integer | yes | 評価（1〜5） |
+| body | string | yes | 口コミ本文 |
+| relationship_status_at_visit | string | yes | 訪問時の関係性（dating / married） |
+
+**レスポンス 201:**
+
+```json
+{
+  "data": {
+    "id": "1",
+    "type": "spot_review",
+    "attributes": {
+      "rating": 4,
+      "body": "とても良いスポットでした。",
+      "relationship_status_at_visit": "dating",
+      "created_at": "2026-06-26T00:00:00.000Z",
+      "user_nickname": "ユーザー名"
+    }
+  }
+}
+```
+
+**エラー:**
+
+- 401: 未認証
+- 404: スポットが存在しない
+- 422: バリデーションエラー
+
+### DELETE /api/v1/spot_reviews/:id
+
+口コミを削除する。認証必須・投稿者本人のみ削除可能。
+
+**レスポンス 204:** ボディなし
+
+**エラー:**
+
+- 401: 未認証
+- 403: 本人以外が削除しようとした
+- 404: 口コミが存在しない
 
 ## いいね（未実装）
 


### PR DESCRIPTION
# 概要
スポットへの口コミ投稿（POST）と削除（DELETE）エンドポイントを実装した。
投稿は認証必須、削除は投稿者本人のみ可能。

## 変更内容

- `docs/api.md` / `api/openapi.yaml`: POST `/api/v1/spots/:id/spot_reviews`、DELETE `/api/v1/spot_reviews/:id` のAPI定義を追加
- `backend/config/routes.rb`: create・destroy のルーティングを追加
- `backend/app/controllers/api/v1/spot_reviews_controller.rb`: create・destroy アクションを実装
- `backend/app/models/spot_review.rb`: 権限チェック用 `owned_by?` メソッドを追加
- `backend/spec/requests/spot_reviews_spec.rb`: 投稿・削除のRequest Specを追加（正常系・認証エラー・権限エラー・バリデーションエラー・404）
- `backend/spec/models/spot_review_spec.rb`: rating の数値バリデーション・`owned_by?` のSpecを追加

## テスト計画

### バックエンド

- [x] `bundle exec rspec` が全件グリーン

## チェックリスト

- [x] APIのエンドポイントを追加・変更した場合、`api/openapi.yaml` を更新した
- [x] `bundle exec rubocop -A` を実行した（バックエンド変更時）